### PR TITLE
Implement Extractable for TextNode

### DIFF
--- a/src/reaver.clj
+++ b/src/reaver.clj
@@ -261,6 +261,37 @@
       (map data elements))))
 
 
+(extend-protocol Extractable
+  TextNode
+  (jsoup
+    [node]
+    node)
+
+  (edn
+    [node]
+    (to-edn node))
+
+  (tag
+    [node]
+    nil)
+
+  (attr*
+    [node attribute]
+    nil)
+
+  (attrs
+    [node]
+    nil)
+
+  (text
+    [node]
+    (.getWholeText node))
+
+  (data
+    [node]
+    nil))
+
+
 (defn attr
   "Convinience function allowing:
 

--- a/src/reaver.clj
+++ b/src/reaver.clj
@@ -293,7 +293,7 @@
 
 
 (defn attr
-  "Convinience function allowing:
+  "Convenience function allowing:
 
      (chain (attr :href) ..)
 


### PR DESCRIPTION
Hi Mischov,

Thanks for the great library! 

I've found it occasionally useful to have `org.jsoup.nodes.TextNode` implement `Extractable` (e.g., when I need to manually filter output of `.childNodes` for elements with a specific tag). So here's an obvious implementation, with `text` returning the node's text verbatim, `jsoup` returning the node, and the other methods returning nil.