### PR TITLE
Remove all reflection

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,4 @@
   :dependencies [[org.jsoup/jsoup "1.8.3"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
                                   [criterium "0.4.3"]]
-                   :warn-on-reflection true}})
+                   :global-vars {*warn-on-reflection* true}}})

--- a/src/reaver.clj
+++ b/src/reaver.clj
@@ -98,7 +98,7 @@
 
    For more on selector syntax, see:
    http://jsoup.org/cookbook/extracting-data/selector-syntax"
-  [^Node node ^String css-selector]
+  [^Element node ^String css-selector]
   (let [^Elements result (.select node css-selector)]
     (if (.isEmpty result)
       nil


### PR DESCRIPTION
This commit has two changes:

1. Update the project.clj to use `:global-vars`
2. Fix a type hint to remove reflection

For the first change, the previous usage of `:warn-on-reflection` is now deprecated. For the second change, we had an incorrect type hint of `Node` when using the `.select` method. `Node` doesn't have that method, but `Element` does. Reflection was covering this for us, but that breaks when using reaver within a Clojure project compiled to a Graal native image.

You can see both of these issues, on master, by using this:

```
❯ lein check
WARNING: :warn-on-reflection is deprecated in project.clj; use :global-vars.
Compiling namespace reaver
Reflection warning, reaver.clj:102:26 - call to method select on org.jsoup.nodes.Node can't be resolved (no such method).
```

Now, with these changes:

```
❯ lein check
Compiling namespace reaver
```