### PR TITLE
Upgrade deps -- includes security fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/mischov/reaver"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.jsoup/jsoup "1.8.3"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
-                                  [criterium "0.4.3"]]
+  :dependencies [[org.jsoup/jsoup "1.18.3"]]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.12.0"]
+                                  [criterium "0.4.6"]]
                    :warn-on-reflection true}})


### PR DESCRIPTION
Since I was here, removing the reflection, I also checked to see if there were any security advisories for these 5+ year old deps. Indeed, jsoup has one here: https://github.com/jhy/jsoup/security/advisories/GHSA-gp7f-rwcx-9369

I've upgraded Clojure and criterium as well, though not for any security fixes. Manual testing, within my project, shows everything is working normally.